### PR TITLE
Update csg_stairs_plugin.gd

### DIFF
--- a/addons/CSGStairs/csg_stairs_plugin.gd
+++ b/addons/CSGStairs/csg_stairs_plugin.gd
@@ -5,7 +5,7 @@ const CSG_STAIR_SCRIPT := preload("csg_stairs.gd")
 const CSG_STAIR_ICON := preload("CSGStairs.svg")
 
 func _enter_tree():
-	add_custom_type("CSGStairs", "Path", CSG_STAIR_SCRIPT, CSG_STAIR_ICON)
+	add_custom_type("CSGStairs", "Path3D", CSG_STAIR_SCRIPT, CSG_STAIR_ICON)
 
 
 func _exit_tree():


### PR DESCRIPTION
Fix for Godot 4.x: extend from `Path3D` not `Path`.